### PR TITLE
ISSUE #575 Hide charts for missing sensors (pressure for example)

### DIFF
--- a/bluetooth_library/build.gradle
+++ b/bluetooth_library/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 30
-        versionCode 10402
-        versionName "1.4.2"
+        versionCode 10403
+        versionName "1.4.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/LogReading.kt
+++ b/bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/LogReading.kt
@@ -6,9 +6,9 @@ data class LogReading (
     var date: Date = Date(),
     var id: String = "",
     var type: GattReadingType = GattReadingType.ALL,
-    var humidity: Double = 0.0,
+    var humidity: Double? = null,
     var temperature: Double = 0.0,
-    var pressure: Double = 0.0,
+    var pressure: Double? = null
 )
 
 enum class GattReadingType {


### PR DESCRIPTION
[CHANGED] Support nullable pressure and humidity for GATT sync
Version bump to 1.4.3